### PR TITLE
Changes from private repo ~June 2018

### DIFF
--- a/ChaseHandle.cs
+++ b/ChaseHandle.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sniper.Lighting.DMX
+{
+    public class ChaseHandle
+    {
+        public List<int> Channels;
+        public int TriggerDirection;
+        public int TriggerValue;
+        public int DurationPerStep;
+        public int MaxRepeatCount;
+        public int CurrentRepeatCount;
+        public byte PulseValue;
+        public int CurrentChannel;
+        public ChaseHandle()
+        {
+            Channels = new List<int>();
+        }
+    }
+}

--- a/DmxDefaults.cs
+++ b/DmxDefaults.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Sniper.Lighting.DMX.Properties;
+
+namespace Sniper.Lighting.DMX
+{
+    public class DmxDefaults
+    {
+        public byte[] Values;
+        public DmxDefaults()
+        {
+            Values = new byte[Settings.Default.DMXChannelCount];
+        }
+    }
+}

--- a/DmxLimits.cs
+++ b/DmxLimits.cs
@@ -14,10 +14,10 @@ namespace Sniper.Lighting.DMX
         {
             Min = new byte[Settings.Default.DMXChannelCount];
             Max = new byte[Settings.Default.DMXChannelCount];
-            int i=0;
-            foreach (byte b in Max)
+
+            for (int i = 0; i < Max.Length; i++)
             {
-                Max[i++] = 255;
+                Max[i] = 255;
             }
         }
     }

--- a/Hold.cs
+++ b/Hold.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sniper.Lighting.DMX
+{
+    public class Hold : Effect
+    {
+        //private Thread thread;
+        internal Hold(Guid Queue, int Channel, int Priority, byte NewValue, byte RevertValue, int Duration) :
+            base(Queue, Channel, Priority, RevertValue, NewValue, Duration, EasingType.Linear, EasingType.Linear, EasingExtents.EaseInOut)
+        {
+        }
+
+        public override byte GetCurrentValue()
+        {
+            if (running)
+            {
+                TimeSpan elapsed = (DateTime.Now - FromTimestamp);
+                return this.NewValue;
+            }
+            return this.OriginalValue;
+        }
+    }
+}

--- a/Sniper.Lighting.DMX.csproj
+++ b/Sniper.Lighting.DMX.csproj
@@ -44,8 +44,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DMXControllerInstance.cs" />
     <Compile Include="DMXDeviceType.cs" />
+    <Compile Include="DmxDefaults.cs" />
     <Compile Include="DmxLimits.cs" />
     <Compile Include="DMXProUSB.cs">
       <SubType>Code</SubType>
@@ -64,6 +64,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
+    <Compile Include="Hold.cs" />
     <Compile Include="Pulse.cs" />
     <Compile Include="QueueBuffer.cs" />
     <Compile Include="StateChangedEventArgs.cs" />
@@ -83,7 +84,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="D:\Work Files\RedBull\Sniper.SkatePark.Automation.Common\Sniper.SkatePark.Automation.Common.csproj">
+    <ProjectReference Include="..\..\..\redbull\redbull\Sniper.SkatePark.Automation.Common\Sniper.SkatePark.Automation.Common.csproj">
       <Project>{512A3A39-611C-4E01-8934-7351D6D4B17B}</Project>
       <Name>Sniper.SkatePark.Automation.Common</Name>
     </ProjectReference>


### PR DESCRIPTION
Fix memory leak in DmxController class when no dmx controller (hardware) is found Build dmx buffer regardless of connection state so that HUD can show expected state when there's lighting controller Allow clearing the queue of future events for a channel ClearFutureQueueForDmxChannel(Guid queue, int channel) Revert to original value not 0 when SetDmxValue revertInDuration is used Implement DmxDefaults to allow universe to have a default state (with some lights on) Disable connection attempt message to avoid cluttering log When not connected to a controller update the state panel more frequently by reducing the blocking sleep, this allows you to use the library in an offline mode Add lighting effect for Effect HoldDmxValue(Guid queue, int channel, int priority, byte newValue, byte revertValue, int duration, int delayDuration) Add ClearEntireQueueForDmxChannel(Guid queue, int channel)